### PR TITLE
Server Crash when using Meka Machines:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,11 +168,16 @@ dependencies {
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
 tasks.named('processResources', ProcessResources).configure {
     var replaceProperties = [
-            minecraft_version: minecraft_version, minecraft_version_range: minecraft_version_range,
-            forge_version: forge_version, forge_version_range: forge_version_range,
+            minecraft_version: minecraft_version,
+            minecraft_version_range: minecraft_version_range,
+            forge_version: forge_version,
+            forge_version_range: forge_version_range,
             loader_version_range: loader_version_range,
-            mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors: mod_authors, mod_description: mod_description,
+            mod_id: mod_id, mod_name: mod_name,
+            mod_license: mod_license,
+            mod_version: mod_version,
+            mod_authors: mod_authors,
+            mod_description: mod_description,
     ]
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Better Forge Chat Reloaded
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.0.3
+mod_version=1.0.4
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/jeremiahbl/bfcrmod/BetterForgeChat.java
+++ b/src/main/java/com/jeremiahbl/bfcrmod/BetterForgeChat.java
@@ -1,16 +1,24 @@
 package com.jeremiahbl.bfcrmod;
 
+import org.slf4j.Logger;
+
 import com.jeremiahbl.bfcrmod.commands.NickCommands;
-import com.jeremiahbl.bfcrmod.config.*;
-import com.jeremiahbl.bfcrmod.events.*;
-import com.jeremiahbl.bfcrmod.utils.*;
+import com.jeremiahbl.bfcrmod.config.ConfigHandler;
+import com.jeremiahbl.bfcrmod.config.ConfigurationEventHandler;
+import com.jeremiahbl.bfcrmod.config.PermissionsHandler;
+import com.jeremiahbl.bfcrmod.events.ChatEventHandler;
+import com.jeremiahbl.bfcrmod.events.CommandRegistrationHandler;
+import com.jeremiahbl.bfcrmod.events.ExternalModLoadingEvent;
+import com.jeremiahbl.bfcrmod.events.PlayerEventHandler;
+import com.jeremiahbl.bfcrmod.utils.BetterForgeChatUtilities;
+import com.jeremiahbl.bfcrmod.utils.IMetadataProvider;
+import com.jeremiahbl.bfcrmod.utils.INicknameProvider;
+import com.jeremiahbl.bfcrmod.utils.loader;
 import com.mojang.logging.LogUtils;
 
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-
-import org.slf4j.Logger;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(BetterForgeChat.MODID )
@@ -18,7 +26,7 @@ public class BetterForgeChat {
 	public static final String CHAT_ID_STR = 
 			"&cBetter &9&lForge&r &eChat&r &d(c) Jeremiah Lowe, Disa Kandria 2022-2024&r\n";
 	public static final String MODID = "bfcrmod";
-	public static final String VERSION = "V1.0.3";
+	public static final String VERSION = "V1.0.4";
     public static final Logger LOGGER = LogUtils.getLogger();
     public static BetterForgeChat instance;
 	
@@ -32,6 +40,7 @@ public class BetterForgeChat {
     private final CommandRegistrationHandler commandRegistrator = new CommandRegistrationHandler();
     private final ConfigurationEventHandler configurationHandler = new ConfigurationEventHandler();
     
+    @SuppressWarnings("removal")
     public BetterForgeChat() {
     	instance = this;
     	// Register reloadable configuration stuff (reduce some things subscribed to the event bus)

--- a/src/main/java/com/jeremiahbl/bfcrmod/commands/NickCommands.java
+++ b/src/main/java/com/jeremiahbl/bfcrmod/commands/NickCommands.java
@@ -35,7 +35,7 @@ public class NickCommands {
 			int oldMin = minNicknameLength;
 			minNicknameLength = maxNicknameLength;
 			maxNicknameLength = oldMin;
-			BetterForgeChat.LOGGER.warn("Minimum nickname length was greater then maximum, swapped vales");
+			BetterForgeChat.LOGGER.warn("Minimum nickname length was greater then maximum, swapped values");
 			BetterForgeChat.LOGGER.warn(minNicknameLength + " < nickname.length() < " + maxNicknameLength);
 		}
 		cfgWhoIsEnabled = ConfigHandler.config.enableWhoisCommand.get();

--- a/src/main/java/com/jeremiahbl/bfcrmod/utils/loader.java
+++ b/src/main/java/com/jeremiahbl/bfcrmod/utils/loader.java
@@ -1,12 +1,13 @@
 package com.jeremiahbl.bfcrmod.utils;
 
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.IConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.network.NetworkConstants;
-import net.minecraftforge.common.MinecraftForge;
 
+@SuppressWarnings("removal")
 public class loader {
 
     static ModLoadingContext mlc = ModLoadingContext.get(); // Get the mod loading context (useful for doing stuff)

--- a/src/main/java/com/jeremiahbl/bfcrmod/utils/moddeps/LuckPermsProvider.java
+++ b/src/main/java/com/jeremiahbl/bfcrmod/utils/moddeps/LuckPermsProvider.java
@@ -2,6 +2,7 @@ package com.jeremiahbl.bfcrmod.utils.moddeps;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import com.jeremiahbl.bfcrmod.BetterForgeChat;
 import com.jeremiahbl.bfcrmod.utils.IMetadataProvider;
 import com.mojang.authlib.GameProfile;
 
@@ -32,10 +33,15 @@ public class LuckPermsProvider implements IMetadataProvider {
 
         @Override
 	public String[] getPlayerPrefixAndSuffix(GameProfile player) {
-		try {
-			CachedMetaData metaData = this.getMetaData(player);
-			return new String[]{metaData.getPrefix(), metaData.getSuffix()};
-		} catch(IllegalStateException ise) {
+		if (this.getMetaData(player) != null){
+			try {
+				CachedMetaData metaData = this.getMetaData(player);
+				return new String[]{metaData.getPrefix(), metaData.getSuffix()};
+			} catch(IllegalStateException | NullPointerException e) {
+				BetterForgeChat.LOGGER.warn("Caught Exception: {} /n If {} is a fake player (added by mod) this warning can be ignored",e,player);
+				return null;
+			}
+		}else{
 			return null;
 		}
 	}


### PR DESCRIPTION
1.0.4 Fixes NullPointerException when attempting to get null metadata for Fake player