### PR TITLE
[forge] added hex color feature to the TextFormatter.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# BetterForgeChat (Fork)
+
+This repository is a fork of BetterForgeChat Reborn.
+
+Changes in this fork:
+- Added hex color support in chat (Format: `&#RRGGBB<Text>`)
+
+Original project:
+https://github.com/Birbs-world/Better-Forge-Chat-Reborn
+
+This fork remains licensed under GPL-3.0, the same license as the original project.
+
 # BetterForgeChat
 A Forge based server-side chat mod to allow prefixes, suffixes and integration with LuckPerms and FTB-Essentials nicknames.
 
@@ -15,32 +27,31 @@ This version is for MC1.20.1 and up. For MC1.18.2 The Original owner no longer h
 ### Markdown support
 ![screenshots/MarkdownSupport.png](https://github.com/Birbs-world/Better-Forge-Chat-Reborn/raw/main/screenshots/MarkdownSupport.png)
 ## Miscellaneous features
- - Works with any (Neo)Forge Permissions plugin to provide easy permission management, see the permissions [on the WiKi](https://github.com/Birbs-world/Better-Forge-Chat-Reborn/wiki)
- - Integrated nickname commands (if not using forge essentials)
+- Works with any (Neo)Forge Permissions plugin to provide easy permission management, see the permissions [on the WiKi](https://github.com/Birbs-world/Better-Forge-Chat-Reborn/wiki)
+- Integrated nickname commands (if not using forge essentials)
 
 ### Highly configurable
- - Customizable timestamp formats
- - Customizable tab-list playername formats
- - All features can be turned on/off easily
- - Customizable permission nodes
- - Out-Of-Box integration with LuckPerms and FTBEssentials
+- Customizable timestamp formats
+- Customizable tab-list playername formats
+- All features can be turned on/off easily
+- Customizable permission nodes
+- Out-Of-Box integration with LuckPerms and FTBEssentials
 
 ## Installation
- - Get the latest version off [CurseForge](https://www.curseforge.com/minecraft/mc-mods/better-forge-chat-reborn-luckperms/files)
- - Add JAR file to serverside `mods/` folder
- - Profit!
+- Get the latest version off [CurseForge](https://www.curseforge.com/minecraft/mc-mods/better-forge-chat-reborn-luckperms/files)
+- Add JAR file to serverside `mods/` folder
+- Profit!
 
 ## Disclaimer
- - While BFCR now has SinglePlayer support, LuckPerms disables its self in SinglePlayer so integration is also disabled 
- - assume any other chat modification mods are incompatible
- - Please submit any issues to GitHub
+- While BFCR now has SinglePlayer support, LuckPerms disables its self in SinglePlayer so integration is also disabled
+- assume any other chat modification mods are incompatible
+- Please submit any issues to GitHub
 
 ## Development
 1.21.1 is in development 1.20.1 is in release
 
 ## Planned features
- - Ability to use colors on sign permission
- - Configurable scheduled server announcements
- - Potential 1.19.x support
- - Potential discord integration
- - Potential Hex Color Handling
+- Ability to use colors on sign permission
+- Configurable scheduled server announcements
+- Potential 1.19.x support
+- Potential discord integrationl

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,14 +46,14 @@ mod_id=bfcrmod
 # The human-readable display name for the mod.
 mod_name=Better Forge Chat Reloaded
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
-mod_license=All Rights Reserved
+mod_license=GPL-3.0
 # The mod version. See https://semver.org/
-mod_version=3.0.0
+mod_version=1.0.9
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
 mod_group_id=com.jermiahbl.bfcrmod
 # The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
-mod_authors=Jeremiah Lowe, Disa Kandria
+mod_authors=Jeremiah Lowe, Disa Kandria, Mintack
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
 mod_description=A better chat mod for Forge./n(with LuckPerms integration)

--- a/src/main/java/com/jeremiahbl/bfcrmod/TextFormatter.java
+++ b/src/main/java/com/jeremiahbl/bfcrmod/TextFormatter.java
@@ -5,158 +5,220 @@ import com.jeremiahbl.bfcrmod.events.ChatEventHandler;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+
+import java.util.Objects;
 
 public final class TextFormatter {
 	public static final String RESET_ALL_FORMAT = "&r";
-	
-	public static final String BOLD_FORMAT          = "&l";
-	public static final String UNDERLINE_FORMAT     = "&n";
-	public static final String ITALIC_FORMAT        = "&o";
-	public static final String OBFUSCATED_FORMAT    = "&k";
+
+	public static final String BOLD_FORMAT = "&l";
+	public static final String UNDERLINE_FORMAT = "&n";
+	public static final String ITALIC_FORMAT = "&o";
+	public static final String OBFUSCATED_FORMAT = "&k";
 	public static final String STRIKETHROUGH_FORMAT = "&m";
-	
-	public static final String COLOR_BLACK =        "&0";
-	public static final String COLOR_DARK_BLUE =    "&1";
-	public static final String COLOR_DARK_GREEN =   "&2";
-	public static final String COLOR_DARK_AQUA =    "&3";
-	public static final String COLOR_DARK_RED =     "&4";
-	public static final String COLOR_DARK_PURPLE =  "&5";
-	public static final String COLOR_GOLD =         "&6";
-	public static final String COLOR_GRAY =         "&7";
-	public static final String COLOR_DARK_GRAY =    "&8";
-	public static final String COLOR_BLUE =         "&9";
-	public static final String COLOR_GREEN =        "&a";
-	public static final String COLOR_AQUA =         "&b";
-	public static final String COLOR_RED =          "&c";
+
+	public static final String COLOR_BLACK = "&0";
+	public static final String COLOR_DARK_BLUE = "&1";
+	public static final String COLOR_DARK_GREEN = "&2";
+	public static final String COLOR_DARK_AQUA = "&3";
+	public static final String COLOR_DARK_RED = "&4";
+	public static final String COLOR_DARK_PURPLE = "&5";
+	public static final String COLOR_GOLD = "&6";
+	public static final String COLOR_GRAY = "&7";
+	public static final String COLOR_DARK_GRAY = "&8";
+	public static final String COLOR_BLUE = "&9";
+	public static final String COLOR_GREEN = "&a";
+	public static final String COLOR_AQUA = "&b";
+	public static final String COLOR_RED = "&c";
 	public static final String COLOR_LIGHT_PURPLE = "&d";
-	public static final String COLOR_YELLOW =       "&e";
-	public static final String COLOR_WHITE =        "&f";
+	public static final String COLOR_YELLOW = "&e";
+	public static final String COLOR_WHITE = "&f";
 
 	public static MutableComponent stringToFormattedText(String msg) {
 		return stringToFormattedText(msg, true, true);
 	}
+
 	public static MutableComponent stringToFormattedText(String msg, boolean enableColors, boolean enableStyles) {
-		ChatFormatting curColor= ChatFormatting.WHITE;
+		TextColor curColor = TextColor.fromLegacyFormat(ChatFormatting.WHITE);
 		String DefaultColor = ChatEventHandler.getChatMessageColor();
-		BetterForgeChat.LOGGER.debug("default Color: {}",DefaultColor);
-		if (!DefaultColor.isEmpty())curColor = ChatFormatting.getByName(DefaultColor);
-		if (curColor==null){
-			curColor=ChatFormatting.WHITE;
+		BetterForgeChat.LOGGER.debug("default Color: {}", DefaultColor);
+		if (!DefaultColor.isEmpty())
+			curColor = TextColor.fromLegacyFormat(Objects.requireNonNullElse(ChatFormatting.getByName(DefaultColor), ChatFormatting.RESET));
+
+		if (curColor == null) {
+			curColor = TextColor.fromLegacyFormat(ChatFormatting.WHITE);
 			BetterForgeChat.LOGGER.error("Chat color in Config is invalid, please check BFCR config file");
 			BetterForgeChat.LOGGER.error("Resetting Global chat message color to White");
 		}
-		BetterForgeChat.LOGGER.debug("final chat color: {}",curColor.getName());
-		if(msg == null) return null;
-		MutableComponent newMsg = Component.empty();
-		boolean nextIsStyle = false;
-		StringBuilder curStr = new StringBuilder();
-		byte curStyle = 0;
-		for(int i = 0; i < ((CharSequence) msg).length(); i++) {
-			char c = ((CharSequence) msg).charAt(i);
-			if(c == '&') {
-				if(nextIsStyle) {
-					nextIsStyle = false;
-					curStr.append("&");
-				} else nextIsStyle = true;
-			} else if(nextIsStyle) {
-				MutableComponent tmp = BitwiseStyling.makeEncapsulatingTextComponent(curStr.toString(), enableStyles ? curStyle : 0);
-				tmp.withStyle(curColor);
-				newMsg.append(tmp);
-				if(enableColors)
-					curColor = getColor(c, curColor);
-				curStr = new StringBuilder();
 
-				if(c == 'r') {
-					curColor = ChatFormatting.getByName(DefaultColor);
-					curStyle = 0;
-				} else curStyle |= BitwiseStyling.getStyleBit(c);
-				nextIsStyle = false;
-			} else curStr.append(c);
+		BetterForgeChat.LOGGER.debug("final chat color: {}", curColor != null ? curColor.toString() : "null");
+		if (msg == null) return null;
+		MutableComponent newMsg = Component.empty();
+
+		String[] splittedMessage = split(msg);
+
+		for (String messagePart : splittedMessage) {
+			if (messagePart.isEmpty()) {
+				continue;
+			}
+			if (messagePart.charAt(0) == '&' && messagePart.charAt(1) != '#') {
+				Style style = getStyle(messagePart.charAt(1), newMsg.getSiblings().isEmpty() ? Style.EMPTY : newMsg.getSiblings().get(newMsg.getSiblings().size()-1).getStyle());
+				newMsg.append(permCheckAndMessageToAppend(enableColors, enableStyles, messagePart, style, false));
+			} else if (messagePart.length() > 7 && messagePart.charAt(0) == '&' && messagePart.charAt(1) == '#') {
+				String hex = messagePart.substring(1, 8);
+				newMsg.append(permCheckAndMessageToAppend(enableColors, enableStyles, messagePart, Style.EMPTY.withColor(TextColor.parseColor(hex)), true));
+			} else {
+				newMsg.append(messagePart);
+			}
 		}
-		if(!curStr.isEmpty()) {
-			MutableComponent tmp = BitwiseStyling.makeEncapsulatingTextComponent(curStr.toString(), enableStyles ? curStyle : 0);
-			tmp.withStyle(curColor);
-			newMsg.append(tmp);
-		}
+
+
 		return newMsg;
 	}
+
+	/**
+	 *
+	 * @param enableColors permissions for colors
+	 * @param enableStyles permissions for styles
+	 * @param messagePart  part of the message (see: return of split())
+	 * @param style        Style to use for Component
+	 * @param hex          if the messagePart will be hex
+	 * @return Component to append to newMsg
+	 */
+	private static Component permCheckAndMessageToAppend(boolean enableColors, boolean enableStyles, String messagePart, Style style, boolean hex) {
+		if (enableColors && enableStyles) {
+			if (hex) {
+				return Component.literal(messagePart.replaceFirst("&#[0-9A-Fa-f]{6}", "")).withStyle(style);
+			} else {
+				return Component.literal(messagePart.replaceFirst("&[0-9a-fk-or]", "")).withStyle(style);
+			}
+		} else if (enableColors && !enableStyles) {
+			if (hex) {
+				return Component.literal(messagePart.replaceFirst("&#[0-9A-Fa-f]{6}", "")).withStyle(style);
+			} else {
+				return Component.literal(messagePart.replaceFirst("&[0-9a-fr]", "")).withStyle(removeStyle(style));
+			}
+		} else if (!enableColors && enableStyles && !hex) {
+			return Component.literal(messagePart.replaceFirst("&[k-or]", "")).withStyle(removeColor(style));
+		} else {
+			return Component.literal(messagePart);
+		}
+	}
+
+	/**
+	 * splits msg by hex colors, legacy colors, and styles.
+	 * each element of the array will begin with a color code (e.g. &5), hex code (e.g. #AABBCC), or style code (e.g. &l)
+	 *
+	 * @param msg the message that should be split
+	 * @return String array split by hex colors, legacy colors, and styles
+	 */
+	private static String[] split(String msg) {
+		return msg.split("(?=(&#[0-9A-Fa-f]{6}|&[0-9a-fk-or]))");
+	}
+
+	private static Style removeStyle(Style style) {
+		return style.withBold(false).withStrikethrough(false).withObfuscated(false).withItalic(false).withUnderlined(false);
+	}
+
+	private static Style removeColor(Style style) {
+		Style tmp = Style.EMPTY.withBold(style.isBold()).withUnderlined(style.isUnderlined()).withItalic(style.isItalic()).withObfuscated(style.isObfuscated()).withStrikethrough(style.isStrikethrough());
+		return style.withColor(ChatFormatting.WHITE).withBold(tmp.isBold()).withUnderlined(tmp.isUnderlined()).withItalic(tmp.isItalic()).withObfuscated(tmp.isObfuscated()).withStrikethrough(tmp.isStrikethrough());
+	}
+
+
 	public static String removeTextFormatting(String msg) {
-		if(msg == null) return null;
+		if (msg == null) return null;
 		StringBuilder newMsg = new StringBuilder();
-        StringBuilder curStr = new StringBuilder();
-        boolean nextIsStyle = false;
-		for(int i = 0; i < msg.length(); i++) {
+		StringBuilder curStr = new StringBuilder();
+		boolean nextIsStyle = false;
+		for (int i = 0; i < msg.length(); i++) {
 			char c = msg.charAt(i);
-			if(c == '&') {
-				if(nextIsStyle) {
+			if (c == '&') {
+				if (nextIsStyle) {
 					nextIsStyle = false;
 					curStr.append("&");
 				} else nextIsStyle = true;
-			} else if(nextIsStyle) {
-				if(isColorOrStyle(c)) {
+			} else if (nextIsStyle) {
+				if (isColorOrStyle(c)) {
 					newMsg.append(curStr);
 					curStr = new StringBuilder();
 				} else curStr.append("&").append(c);
 				nextIsStyle = false;
 			} else curStr.append(c);
 		}
-		if(!curStr.isEmpty())
+		if (!curStr.isEmpty())
 			newMsg.append(curStr);
 		return newMsg.toString();
 	}
 
 	public static boolean messageContainsColorsOrStyles(String msg, boolean checkColors) {
 		boolean checkNext = false;
-		for(int i = 0; i < msg.length(); i++) {
+		for (int i = 0; i < msg.length(); i++) {
 			char c = msg.charAt(i);
-			if(c == '&') {
-                checkNext = !checkNext;
-			} else if(checkNext) {
-				if(checkColors) { if(isColor(c)) return true; }
-				else { if(isStyle(c)) return true; }
+			if (c == '&') {
+				checkNext = !checkNext;
+			} else if (checkNext) {
+				if (checkColors) {
+					if (isColor(c)) return true;
+				} else {
+					if (isStyle(c)) return true;
+				}
 			}
 		}
 		return false;
 	}
+
 	public static String colorString() {
 		return """
-                       &fLight:  &c&&c &e&&e &9&&9 &a&&a &b&&b &d&&d &f&&f &7&&7
-                       &fDark:   &4&&4 &6&&6 &1&&1 &2&&2 &3&&3 &5&&5 &0&&0 &8&&8
-                       &fStyles: &l&&l&r &n&&n&r &o&&o&r &m&&m&r &k&&k&r
-                       """;
+                &fLight:  &c&&c &e&&e &9&&9 &a&&a &b&&b &d&&d &f&&f &7&&7
+                &fDark:   &4&&4 &6&&6 &1&&1 &2&&2 &3&&3 &5&&5 &0&&0 &8&&8
+                &fStyles: &l&&l&r &n&&n&r &o&&o&r &m&&m&r &k&&k&r
+                """;
 	}
 
-	private static ChatFormatting getColor(char c, ChatFormatting cur) {
-            return switch (c) {
-                case '0' -> ChatFormatting.BLACK;
-                case '1' -> ChatFormatting.DARK_BLUE;
-                case '2' -> ChatFormatting.DARK_GREEN;
-                case '3' -> ChatFormatting.DARK_AQUA;
-                case '4' -> ChatFormatting.DARK_RED;
-                case '5' -> ChatFormatting.DARK_PURPLE;
-                case '6' -> ChatFormatting.GOLD;
-                case '7' -> ChatFormatting.GRAY;
-                case '8' -> ChatFormatting.DARK_GRAY;
-                case '9' -> ChatFormatting.BLUE;
-                case 'a' -> ChatFormatting.GREEN;
-                case 'b' -> ChatFormatting.AQUA;
-                case 'c' -> ChatFormatting.RED;
-                case 'd' -> ChatFormatting.LIGHT_PURPLE;
-                case 'e' -> ChatFormatting.YELLOW;
-                case 'f', 'r' -> ChatFormatting.WHITE;
-                default -> cur;
-            }; // Reset
-    }
+	private static Style getStyle(char c, Style currentStyle) {
+		return switch (c) {
+			case '0' -> Style.EMPTY.withColor(ChatFormatting.BLACK);
+			case '1' -> Style.EMPTY.withColor(ChatFormatting.DARK_BLUE);
+			case '2' -> Style.EMPTY.withColor(ChatFormatting.DARK_GREEN);
+			case '3' -> Style.EMPTY.withColor(ChatFormatting.DARK_AQUA);
+			case '4' -> Style.EMPTY.withColor(ChatFormatting.DARK_RED);
+			case '5' -> Style.EMPTY.withColor(ChatFormatting.DARK_PURPLE);
+			case '6' -> Style.EMPTY.withColor(ChatFormatting.GOLD);
+			case '7' -> Style.EMPTY.withColor(ChatFormatting.GRAY);
+			case '8' -> Style.EMPTY.withColor(ChatFormatting.DARK_GRAY);
+			case '9' -> Style.EMPTY.withColor(ChatFormatting.BLUE);
+			case 'a' -> Style.EMPTY.withColor(ChatFormatting.GREEN);
+			case 'b' -> Style.EMPTY.withColor(ChatFormatting.AQUA);
+			case 'c' -> Style.EMPTY.withColor(ChatFormatting.RED);
+			case 'd' -> Style.EMPTY.withColor(ChatFormatting.LIGHT_PURPLE);
+			case 'e' -> Style.EMPTY.withColor(ChatFormatting.YELLOW);
+			case 'f', 'r' -> Style.EMPTY.withColor(ChatFormatting.WHITE);
+
+			case 'l' -> currentStyle.withBold(true);
+			case 'n' -> currentStyle.withUnderlined(true);
+			case 'o' -> currentStyle.withItalic(true);
+			case 'k' -> currentStyle.withObfuscated(true);
+			case 'm' -> currentStyle.withStrikethrough(true);
+			default -> currentStyle;
+		}; // Reset
+	}
+
+
 	private static boolean isColorOrStyle(char c) {
 		return isColor(c) || isStyle(c);
 	}
+
 	private static boolean isColor(char c) {
-		if(c >= '0' && c <= '9') return true;
-        return c >= 'a' && c <= 'f';
-    }
-    private static boolean isStyle(char c) {
-    	if(c >= 'k' && c <= 'o') return true;
-        return c == 'r';
-    }
-    
+		if (c >= '0' && c <= '9') return true;
+		return c >= 'a' && c <= 'f';
+	}
+
+	private static boolean isStyle(char c) {
+		if (c >= 'k' && c <= 'o') return true;
+		return c == 'r';
+	}
+
 }


### PR DESCRIPTION
The TextFormatter class is changed in this pull request so it supports hex colors.
Key Changes:
- Using Style and TextColor to support modern Minecraft text features.
- Hex Color Support using the format &#RRGGBB (e.g. "&#FFBB00Test")
- RegEx based Parsing: replaced the character loop with a split() method
- replaced getColor() with getStyle()

I changed the parsing to RegEx, because I found it difficult to extend hex codes using the character loop that was used before.

I tested the following:
- & color codes still work
- & style codes combined with color codes still work
- hex color codes like &#FFFF11 work, also combined with & style codes
- tested with luckperms prefix