### PR TITLE
fix: guard null LuckPerms metadata for fake players

### DIFF
--- a/src/main/java/com/rvt/bfcrmod/utils/moddeps/LuckPermsProvider.java
+++ b/src/main/java/com/rvt/bfcrmod/utils/moddeps/LuckPermsProvider.java
@@ -2,6 +2,7 @@ package com.rvt.bfcrmod.utils.moddeps;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import com.rvt.bfcrmod.BetterForgeChat;
 import com.rvt.bfcrmod.utils.IMetadataProvider;
 import com.mojang.authlib.GameProfile;
 
@@ -32,11 +33,15 @@ public class LuckPermsProvider implements IMetadataProvider {
 
         @Override
 	public String[] getPlayerPrefixAndSuffix(GameProfile player) {
-		try {
-			CachedMetaData metaData = this.getMetaData(player);
-            assert metaData != null;
-            return new String[]{metaData.getPrefix(), metaData.getSuffix()};
-		} catch(IllegalStateException ise) {
+		if (this.getMetaData(player) != null){
+			try {
+				CachedMetaData metaData = this.getMetaData(player);
+				return new String[]{metaData.getPrefix(), metaData.getSuffix()};
+			} catch(IllegalStateException | NullPointerException e) {
+				BetterForgeChat.LOGGER.warn("Caught Exception: {} /n If {} is a fake player (added by mod) this warning can be ignored",e,player);
+				return null;
+			}
+		}else{
 			return null;
 		}
 	}


### PR DESCRIPTION
Fake players (e.g. Mob Grinding Utils mob mashers killing mobs) have no LuckPerms user, so getMetaData returns null and the unchecked dereference threw a NullPointerException mid-tick, crashing the server. Null-check before use and broaden the catch to NPE.

Backport of upstream issue #7 / PR #8, never merged into the neoforge-1.21.1 branch.